### PR TITLE
Fix #20 : Add JS Doc linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -172,7 +172,7 @@
     "spaced-comment": [2, "always"],
     "strict": 0,
     "use-isnan": 2,
-    "valid-jsdoc": 0,
+    "valid-jsdoc": [2, {"requireReturn": false}],
     "valid-typeof": 2,
     "vars-on-top": 2,
     "wrap-iife": [2, "any"],


### PR DESCRIPTION
Using `"requireReturn": false` (requires the return tag if and only if the function or method has a return statement)
